### PR TITLE
Topic/undef stash

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Release history for Pod-Weaver-Section-Contributors
 
+    - fix errors when trying to access a non-existent stash (v0.004, ETHER)
+
 0.004   2013-05-10 16:39:14 Asia/Seoul
     - contributor names are added back into [%PodWeaver] for
       Pod::Weaver::Plugin::StopWords (ETHER)

--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -57,7 +57,7 @@ sub weave_section {
     ## 1 - add contributors passed to Dist::Zilla::Stash::PodWeaver
     if ( $input->{zilla} ) {
         my $stash = $input->{zilla}->stash_named('%PodWeaver');
-        $stash->merge_stashed_config($self);
+        $stash->merge_stashed_config($self) if $stash;
     }
 
     ## 2 - get contributors passed to Pod::Weaver::Section::Contributors
@@ -85,10 +85,12 @@ sub weave_section {
     return unless @contributors;
 
     ## 6 - add contributors to the stash as stopwords
-    if ( $input->{zilla} ) {
-        my $stash = $self->zilla->stash_named('%PodWeaver');
-        do { $stash = PodWeaver->new; $self->_register_stash('%PodWeaver', $stash) }
-            unless defined $stash;
+    if ( $input->{zilla}
+        and my $stash = $input->{zilla}->stash_named('%PodWeaver')
+    ) {
+        # TODO: no good way yet of registering a stash from a weaver section
+        #do { $stash = PodWeaver->new; $self->_register_stash('%PodWeaver', $stash) }
+        #    unless defined $stash;
         my $config = $stash->_config;
 
         my @stopwords = uniq


### PR DESCRIPTION
I found this while adding [Contributors] to my author plugin bundle's weaver.ini, when [ContributorsFromGit] wasn't in the bundle yet (I don't use [Bootstrap::lib] to build myself) -- so the PodWeaver stash didn't exist! ([ContributorsFromGit] creates it if it doesn't exist). :o

So sorry! :/
