### PR TITLE
Escape signs around email for pod top prevent errors in podlint

### DIFF
--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -123,6 +123,9 @@ sub weave_section {
     @contributors = uniq (@contributors);
     @contributors = sort (@contributors);
 
+    #escape < and > signs around author emails for the Pod
+    s/\<(.*)\>/E\<lt\>$1E\<gt\>/ for @contributors;
+
     return unless @contributors;
 
     ## 6 - add contributors to the stash as stopwords


### PR DESCRIPTION
Thanks for this module. It has proven quiet useful to me.
While you can get by without escaping < and > signs in Pod documentation most of the time, its neither a good practice nor is it fun when things break down. I added a single line to escape those signs for Pod documentation. 
HTH,
-Shantanu Bhadoria
