### PR TITLE
Creates a ::ReplaceContributors version of this section plugin

### DIFF
--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -64,6 +64,20 @@ has all_modules => (
     default => 0,
 );
 
+=attr include_stopwords
+
+A boolean flag to turn on/off the inclusion of a list of stopwords compiled
+from the names of contributors. True by default.
+
+=cut
+
+has include_stopwords => (
+    is      => 'rw',
+    isa     => 'Bool',
+    lazy    => 1,
+    default => 0,
+);
+
 =for Pod::Coverage weave_section
 =cut
 
@@ -146,14 +160,16 @@ sub weave_section {
     # pass list of contributors to the StopWords plugin and Pod::Spell via directives
     #
 
-    my @stopwords = uniq
-        map { $_ ? split / / : ()    }
-        map { /^(.*?)(\s+<.*)?$/; $1 }
-        @contributors;
+    if( $self->include_stopwords ){
+        my @stopwords = uniq
+            map { $_ ? split / / : ()    }
+            map { /^(.*?)(\s+<.*)?$/; $1 }
+            @contributors;
 
-    unshift @$result, Pod::Elemental::Element::Pod5::Command->new({
-        command => 'for', content => join(' ', 'stopwords', @stopwords),
-    });
+        unshift @$result, Pod::Elemental::Element::Pod5::Command->new({
+            command => 'for', content => join(' ', 'stopwords', @stopwords),
+        });
+    }
 
 
     #

--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -75,7 +75,7 @@ has include_stopwords => (
     is      => 'rw',
     isa     => 'Bool',
     lazy    => 1,
-    default => 0,
+    default => 1,
 );
 
 =for Pod::Coverage weave_section

--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -111,6 +111,12 @@ sub weave_section {
         push(@contributors, @$_contributors);
     }
 
+    ## get contributors from META.{json,yml}
+    if ($input->{meta}
+            and my $_contributors = $input->{meta}{x_contributors}) {
+        push(@contributors, @$_contributors);
+    }
+
     ## get contributors from source comments
     my $ppi_document = $input->{ppi_document};
     $ppi_document->find( sub {

--- a/lib/Pod/Weaver/Section/ReplaceContributors.pm
+++ b/lib/Pod/Weaver/Section/ReplaceContributors.pm
@@ -7,6 +7,7 @@ with 'Pod::Weaver::Role::SectionReplacer';
 sub mvp_multivalue_args { qw( contributors ) }
 sub default_section_name { 'CONTRIBUTORS' }
 # sub default_section_aliases { [ 'CONTRIBUTOR' ] }
+has '+include_stopwords' => ( default => 0 );
 
 no Moose;
 1;
@@ -41,6 +42,10 @@ and/or in the source of individual files:
 This section plugin provides the same behaviour as
 Pod::Weaver::Section::Contributors but with the
 Pod::Weaver::Role::SectionReplacer role applied.
+
+Pod::Weaver::Role::SectionReplacer does not play nicely with C<=for stopword>,
+so, unlink Pod::Weaver::Section::Contributors, stopwords are not added to the
+document when using Pod::Weaver::Section::ReplaceContributors.
 
 This section adds a listing of the documents contributors.  It expects a C<contributors>
 input parameter to be an arrayref of strings.  If no C<contributors> parameter is

--- a/lib/Pod/Weaver/Section/ReplaceContributors.pm
+++ b/lib/Pod/Weaver/Section/ReplaceContributors.pm
@@ -1,0 +1,72 @@
+package Pod::Weaver::Section::ReplaceContributors;
+use Moose;
+extends 'Pod::Weaver::Section::Contributors';
+with 'Pod::Weaver::Role::SectionReplacer';
+# ABSTRACT: replaces a section listing contributors
+
+sub mvp_multivalue_args { qw( contributors ) }
+sub default_section_name { 'CONTRIBUTORS' }
+# sub default_section_aliases { [ 'CONTRIBUTOR' ] }
+
+no Moose;
+1;
+
+__END__
+=pod
+
+=head1 SYNOPSIS
+
+on dist.ini:
+
+    [PodWeaver]
+    [%PodWeaver]
+    Contributors.head = 2
+    Contributors.contributors[0] = keedi - Keedi Kim - 김도형 (cpan: KEEDI) <keedi@cpan.org>
+    Contributors.contributors[1] = carandraug - Carnë Draug (cpan: CDRAUG) <cdraug@cpan.org>
+
+and/or weaver.ini:
+
+    [Contributors]
+    head = 2
+    contributors = keedi - Keedi Kim - 김도형 (cpan: KEEDI) <keedi@cpan.org>
+    contributors = carandraug - Carnë Draug (cpan: CDRAUG) <cdraug@cpan.org>
+
+and/or in the source of individual files:
+
+    # CONTRIBUTOR:  keedi - Keedi Kim - 김도형 (cpan: KEEDI) <keedi@cpan.org>
+    # CONTRIBUTORS: carandraug - Carnë Draug (cpan: CDRAUG) <cdraug@cpan.org>
+
+=head1 DESCRIPTION
+
+This section plugin provides the same behaviour as
+Pod::Weaver::Section::Contributors but with the
+Pod::Weaver::Role::SectionReplacer role applied.
+
+This section adds a listing of the documents contributors.  It expects a C<contributors>
+input parameter to be an arrayref of strings.  If no C<contributors> parameter is
+given, it will do nothing.  Otherwise, it produces a hunk like this:
+
+    =head1 CONTRIBUTORS
+
+    Contributor One <a1@example.com>
+    Contributor Two <a2@example.com>
+
+To support distributions with multiple modules, it is also able to derive a list
+of contributors in a file basis by looking at comments on each module. Names of
+contributors on the source, will only appear on the POD of those modules.
+
+=head1 SEE ALSO
+
+=for :list
+* L<dagolden's 'How I'm using Dist::Zilla to give credit to contributors'|http://www.dagolden.com/index.php/1921/how-im-using-distzilla-to-give-credit-to-contributors/>
+* L<Dist::Zilla::Plugin::ContributorsFromGit>
+* L<Dist::Zilla::Stash::Contributors>
+* L<Dist::Zilla::Plugin::Meta::Contributors>
+* L<Dist::Zilla::Plugin::ContributorsFile>
+* L<Dist::Zilla>
+* L<Dist::Zilla::Stash::PodWeaver>
+* L<Pod::Weaver>
+* L<Pod::Weaver::Section::Authors>
+
+
+=cut


### PR DESCRIPTION
- Uses the Pod::Weaver::Role::SectionReplacer role to replace the
  section if it already exists. This is useful for standalone podweaver
  usage. It has been used/proven in:
    Pod::Weaver::PluginBundle::ReplaceBoilerplate
    Pod::Weaver::Section::Replace{Name,Version,Authors,etc}
