### PR TITLE
switch off of List::MoreUtils, and sort the contributors list

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Release history for Pod-Weaver-Section-Contributors
 
     - switch off of List::MoreUtils (ETHER)
+    - sort the contributors list (ETHER)
 
 0.009   2014-12-22 11:51:10 Asia/Seoul
     - remove the use of autobox (ETHER)

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Release history for Pod-Weaver-Section-Contributors
 
+    - switch off of List::MoreUtils (ETHER)
+
 0.009   2014-12-22 11:51:10 Asia/Seoul
     - remove the use of autobox (ETHER)
 

--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -3,7 +3,7 @@ use Moose;
 with 'Pod::Weaver::Role::Section';
 # ABSTRACT: a section listing contributors
 
-use List::MoreUtils 'uniq';
+use List::Util 1.45 'uniq';
 
 use Pod::Elemental::Element::Nested;
 use Pod::Elemental::Element::Pod5::Verbatim;

--- a/lib/Pod/Weaver/Section/Contributors.pm
+++ b/lib/Pod/Weaver/Section/Contributors.pm
@@ -108,8 +108,8 @@ sub weave_section {
         return 0;
     });
 
-    ## remove repeated names
-    @contributors = uniq (@contributors);
+    ## remove repeated names and sort
+    @contributors = uniq sort (@contributors);
 
     return unless @contributors;
 


### PR DESCRIPTION
List::Util (in core) now contains an implementation of `uniq`, so we don't need to use List::MoreUtils.
